### PR TITLE
Add --compare mode

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -1,0 +1,108 @@
+package compare
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/chainguard-dev/yacls/v2/pkg/platform"
+)
+
+type Change struct {
+	Kind     string
+	Entity   string
+	Mod      string
+	FromDate string
+	ToDate   string
+}
+
+func Summary(from platform.Artifact, to platform.Artifact) ([]Change, error) {
+	cs := []Change{}
+	fromU := map[string]platform.User{}
+	toU := map[string]platform.User{}
+	fromGroups := map[string][]string{}
+	toGroups := map[string][]string{}
+
+	fromGroupPerms := map[string][]string{}
+	toGroupPerms := map[string][]string{}
+
+	kind := to.Metadata.Kind
+	fromDate := from.Metadata.SourceDate
+	toDate := to.Metadata.SourceDate
+
+	for _, u := range from.Users {
+		fromU[u.Account] = u
+	}
+
+	for _, g := range from.Groups {
+		fromGroups[g.Name] = g.Members
+		fromGroupPerms[g.Name] = g.Permissions
+	}
+
+	for _, u := range to.Users {
+		toU[u.Account] = u
+		_, exists := fromU[u.Account]
+		if !exists {
+			cs = append(cs, Change{Kind: kind, Entity: u.Account, Mod: "add user", FromDate: fromDate, ToDate: toDate})
+			continue
+		}
+	}
+
+	for _, g := range to.Groups {
+		toGroups[g.Name] = g.Members
+		toGroupPerms[g.Name] = g.Permissions
+	}
+
+	for acct, fu := range fromU {
+		tu, exists := toU[acct]
+		if !exists {
+			cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: "remove user", FromDate: fromDate, ToDate: toDate})
+			continue
+		}
+
+		for _, p := range fu.Permissions {
+			if !slices.Contains(tu.Permissions, p) {
+				cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: fmt.Sprintf("remove permission: %q", p), FromDate: fromDate, ToDate: toDate})
+			}
+		}
+
+		for _, p := range tu.Permissions {
+			if !slices.Contains(fu.Permissions, p) {
+				cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: fmt.Sprintf("add permission: %q", p), FromDate: fromDate, ToDate: toDate})
+			}
+		}
+	}
+
+	for name, members := range fromGroups {
+		for _, m := range members {
+			if !slices.Contains(toGroups[name], m) {
+				cs = append(cs, Change{Kind: kind, Entity: m, Mod: fmt.Sprintf("left group: %q", name), FromDate: fromDate, ToDate: toDate})
+			}
+		}
+	}
+
+	for name, members := range toGroups {
+		for _, m := range members {
+			if !slices.Contains(fromGroups[name], m) {
+				cs = append(cs, Change{Kind: kind, Entity: m, Mod: fmt.Sprintf("joined group: %q", name), FromDate: fromDate, ToDate: toDate})
+			}
+		}
+	}
+
+	for g, ps := range fromGroupPerms {
+		for _, p := range ps {
+			if !slices.Contains(toGroupPerms[g], p) {
+				cs = append(cs, Change{Kind: kind, Entity: g, Mod: fmt.Sprintf("lost permission: %q", p), FromDate: fromDate, ToDate: toDate})
+			}
+		}
+	}
+
+	for g, ps := range toGroupPerms {
+		for _, p := range ps {
+			if !slices.Contains(fromGroupPerms[g], p) {
+				cs = append(cs, Change{Kind: kind, Entity: g, Mod: fmt.Sprintf("gained permission: %q", p), FromDate: fromDate, ToDate: toDate})
+			}
+		}
+	}
+
+	return cs, nil
+}

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -61,13 +61,13 @@ func Summary(from platform.Artifact, to platform.Artifact) ([]Change, error) {
 
 		for _, p := range fu.Permissions {
 			if !slices.Contains(tu.Permissions, p) {
-				cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: fmt.Sprintf("remove permission: %q", p), FromDate: fromDate, ToDate: toDate})
+				cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: fmt.Sprintf("remove permission: %s", p), FromDate: fromDate, ToDate: toDate})
 			}
 		}
 
 		for _, p := range tu.Permissions {
 			if !slices.Contains(fu.Permissions, p) {
-				cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: fmt.Sprintf("add permission: %q", p), FromDate: fromDate, ToDate: toDate})
+				cs = append(cs, Change{Kind: kind, Entity: fu.Account, Mod: fmt.Sprintf("add permission: %s", p), FromDate: fromDate, ToDate: toDate})
 			}
 		}
 	}
@@ -75,7 +75,7 @@ func Summary(from platform.Artifact, to platform.Artifact) ([]Change, error) {
 	for name, members := range fromGroups {
 		for _, m := range members {
 			if !slices.Contains(toGroups[name], m) {
-				cs = append(cs, Change{Kind: kind, Entity: m, Mod: fmt.Sprintf("left group: %q", name), FromDate: fromDate, ToDate: toDate})
+				cs = append(cs, Change{Kind: kind, Entity: m, Mod: fmt.Sprintf("left group: %s", name), FromDate: fromDate, ToDate: toDate})
 			}
 		}
 	}
@@ -83,7 +83,7 @@ func Summary(from platform.Artifact, to platform.Artifact) ([]Change, error) {
 	for name, members := range toGroups {
 		for _, m := range members {
 			if !slices.Contains(fromGroups[name], m) {
-				cs = append(cs, Change{Kind: kind, Entity: m, Mod: fmt.Sprintf("joined group: %q", name), FromDate: fromDate, ToDate: toDate})
+				cs = append(cs, Change{Kind: kind, Entity: m, Mod: fmt.Sprintf("joined group: %s", name), FromDate: fromDate, ToDate: toDate})
 			}
 		}
 	}

--- a/yacls.go
+++ b/yacls.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chainguard-dev/yacls/v2/pkg/compare"
 	"github.com/chainguard-dev/yacls/v2/pkg/platform"
 	"github.com/chainguard-dev/yacls/v2/pkg/server"
+	"github.com/gocarina/gocsv"
 
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
@@ -60,9 +61,12 @@ func main() {
 		if err != nil {
 			log.Fatalf("compare failed: %v", err)
 		}
-		for _, c := range changes {
-			fmt.Printf("%v\n", c)
+
+		s, err := gocsv.MarshalString(&changes)
+		if err != nil {
+			log.Fatalf("marshal: %v", err)
 		}
+		fmt.Println(s)
 		os.Exit(0)
 	}
 

--- a/yacls.go
+++ b/yacls.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/chainguard-dev/yacls/v2/pkg/compare"
 	"github.com/chainguard-dev/yacls/v2/pkg/platform"
 	"github.com/chainguard-dev/yacls/v2/pkg/server"
 
@@ -32,6 +33,7 @@ func kindHelp() string {
 
 var (
 	inputFlag              = flag.String("input", "", "path to input file")
+	compareFlag            = flag.String("compare", "", "path to file to compare against")
 	projectFlag            = flag.String("project", "", "specific project to process within the kind")
 	gcpIdentityProjectFlag = flag.String("gcp-identity-project", "", "project to use for GCP Cloud Identity lookups")
 	kindFlag               = flag.String("kind", "", fmt.Sprintf("kind of input to process. valid values: \n  * %s\n%s", strings.Join(platform.AvailableKinds(), "\n  * "), kindHelp()))
@@ -53,6 +55,47 @@ func main() {
 		os.Exit(0)
 	}
 
+	if *compareFlag != "" {
+		changes, err := compareSummary(*inputFlag, *compareFlag)
+		if err != nil {
+			log.Fatalf("compare failed: %v", err)
+		}
+		for _, c := range changes {
+			fmt.Printf("%v\n", c)
+		}
+		os.Exit(0)
+	}
+
+	generate()
+}
+
+func compareSummary(fromPath string, toPath string) ([]compare.Change, error) {
+	cs := []compare.Change{}
+	bs, err := os.ReadFile(fromPath)
+	if err != nil {
+		return cs, fmt.Errorf("read: %w", err)
+	}
+
+	from := platform.Artifact{}
+	if err := yaml.Unmarshal(bs, &from); err != nil {
+		return cs, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	bs, err = os.ReadFile(toPath)
+	if err != nil {
+		return cs, fmt.Errorf("read: %w", err)
+	}
+
+	to := platform.Artifact{}
+	if err := yaml.Unmarshal(bs, &to); err != nil {
+		return cs, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	return compare.Summary(from, to)
+}
+
+// generate is the common path for generating and outputting YAML
+func generate() {
 	inputs := []string{}
 	if *inputFlag != "" {
 		inputs = append(inputs, *inputFlag)


### PR DESCRIPTION
Allows you to see a list of differences (drift) between two artifacts.

Useful for SOC-2 audits.