### PR TITLE
Handle GCP Principal kind

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -30,6 +30,9 @@ type Artifact struct {
 	ServiceAccountCount int    `yaml:"service_accounts_total,omitempty"`
 	ServiceAccounts     []User `yaml:"service_accounts,omitempty"`
 
+	PrincipalCount int    `yaml:"principals_total,omitempty"`
+	Principal     []User `yaml:"principals,omitempty"`
+
 	GroupCount  int                 `yaml:"groups_total,omitempty"`
 	Groups      []Group             `yaml:"groups,omitempty"`
 	OrgCount    int                 `yaml:"orgs_total,omitempty"`
@@ -46,6 +49,8 @@ type Permissions struct {
 	Users               map[string]User  `yaml:"users,omitempty"`
 	ServiceAccountCount int              `yaml:"service_accounts_total,omitempty"`
 	ServiceAccounts     map[string]User  `yaml:"service_accounts,omitempty"`
+	PrincipalCount           int              `yaml:"principals_total,omitempty"`
+	Principals               map[string]User  `yaml:"principals,omitempty"`
 	GroupCount          int              `yaml:"groups_total,omitempty"`
 	Groups              map[string]Group `yaml:"groups,omitempty"`
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -31,7 +31,7 @@ type Artifact struct {
 	ServiceAccounts     []User `yaml:"service_accounts,omitempty"`
 
 	PrincipalCount int    `yaml:"principals_total,omitempty"`
-	Principal     []User `yaml:"principals,omitempty"`
+	Principal      []User `yaml:"principals,omitempty"`
 
 	GroupCount  int                 `yaml:"groups_total,omitempty"`
 	Groups      []Group             `yaml:"groups,omitempty"`
@@ -49,8 +49,8 @@ type Permissions struct {
 	Users               map[string]User  `yaml:"users,omitempty"`
 	ServiceAccountCount int              `yaml:"service_accounts_total,omitempty"`
 	ServiceAccounts     map[string]User  `yaml:"service_accounts,omitempty"`
-	PrincipalCount           int              `yaml:"principals_total,omitempty"`
-	Principals               map[string]User  `yaml:"principals,omitempty"`
+	PrincipalCount      int              `yaml:"principals_total,omitempty"`
+	Principals          map[string]User  `yaml:"principals,omitempty"`
 	GroupCount          int              `yaml:"groups_total,omitempty"`
 	Groups              map[string]Group `yaml:"groups,omitempty"`
 }


### PR DESCRIPTION
This results in the GCP output YAMLs getting a new sections `principals:`. Example:

```yaml
principals:
        iam.googleapis.com/projects/234031620436/locations/global/workloadIdentityPools/vanta-77f4d8052d00a1e/subject/vanta-scanner:
            roles:
                - organizations/959935394837/VantaOrganizationScanner (Custom)
                - iam.securityReviewer (Security reviewer role, with permissions to get any IAM policy)
```